### PR TITLE
Don't perform case sensitive matching during handshake

### DIFF
--- a/src/Engine/Socket.php
+++ b/src/Engine/Socket.php
@@ -213,7 +213,7 @@ class Socket
             } else {
                 if ($header) {
                     $this->result['headers'][] = trim($content);
-                    if (null === $len && 'Content-Length:' === substr($content, 0, 15)) {
+                    if (null === $len && 0 === stripos($content, 'Content-Length:')) {
                         $len = (int) trim(substr($content, 16));
                     }
                 } else {


### PR DESCRIPTION
Hello, first, thanks for maintaining elephant.io!
At work, in our stack, something puts header names in lowercase so I've had to do a case insensitive matching for the Content-Length in the handshake otherwise it fails.
Hope it'll help other people!