### PR TITLE
Use defined headers

### DIFF
--- a/src/Engine/Socket.php
+++ b/src/Engine/Socket.php
@@ -189,6 +189,10 @@ class Socket
             }
         }
 
+        if(isset($this->options['headers'])){
+            $headers = array_merge($headers, $this->options['headers']);
+        }
+
         $request = array_merge([
             sprintf('%s %s HTTP/1.1', strtoupper($method), $uri),
             sprintf('Host: %s', $this->parsed['host'] . ':' . $this->parsed['port']),


### PR DESCRIPTION
Hey,

I'm using `socketio-jwt` (NodeJS Server Side Package) to check for a Authorization header and validate it using jwt.
For that I need to add a header, but elephant.io never applys defined headers. I don't know why and I hope it is the right place to add them.

```
$elephant = new ElephantIO\Client(new \ElephantIO\Engine\SocketIO\Version3X('https://domain.de:4101', array(
                'headers' => [
                    'Authorization: Bearer tokenabc'
                ]
            )));
```

Looking forward to your feedback^^

~ Marius